### PR TITLE
Remove absolute path in grpcurl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -tid \
 The utility `grpcurl` can be used to test the mock server using the
 following command:
 ```bash
-grpcurl -proto $(pwd)/example/greeter.proto \
+grpcurl -proto example/greeter.proto \
   -plaintext \
   -d '{"message": "Hello"}' \
   localhost:50051 greeter.Greeter/Hello
@@ -32,7 +32,7 @@ In the `example` directory there is input samples for the streaming requests to 
 you can issue commands similar to the following (substituting the appropriate input file and
 method name):
 ```bash
-cat example/chat-1.json | grpcurl -proto $(pwd)/example/greeter.proto \
+cat example/chat-1.json | grpcurl -proto example/greeter.proto \
   -plaintext -d @ localhost:50051 greeter.Greeter/Chat
 ```
 


### PR DESCRIPTION
The following error message shows when we use `$(pwd)` with grpcurl 1.5.1:

```
Failed to process proto source files.: must specify at least one import path if any absolute file paths are given
```

One approach is to add `-import-path` as following:

```
grpcurl -import-path $(pwd) -proto example/greeter.proto \
...
```

But I think that just removing `$(pwd)` is simpler:

```
grpcurl -proto example/greeter.proto \
...
```